### PR TITLE
Friendly calendar dates, using 'today', 'tonight', 'tomorrow' and day names

### DIFF
--- a/env.sh.sample
+++ b/env.sh.sample
@@ -17,8 +17,8 @@
 # export WEATHERGOV_SELF_IDENTIFICATION=you@example.com
 
 # Your latitude and longitude to pass to weather providers
-export WEATHER_LATITUDE=51.3656
-export WEATHER_LONGITUDE=0.1963
+export WEATHER_LATITUDE=51.5077
+export WEATHER_LONGITUDE=-0.1277
 
 # Choose CELSIUS or FAHRENHEIT
 export WEATHER_FORMAT=CELSIUS

--- a/outlook_util.py
+++ b/outlook_util.py
@@ -8,7 +8,7 @@ import atexit
 import os
 import time
 from datetime import timezone
-from utility import configure_logging
+from utility import configure_logging, get_formatted_date
 from dateutil import tz
 
 configure_logging()
@@ -75,7 +75,7 @@ def get_outlook_datetime_formatted(event):
     end_date = datetime.datetime.strptime(event["end"]["dateTime"], "%Y-%m-%dT%H:%M:%S.0000000")
     
     if event['isAllDay'] == True:
-        day = start_date.strftime("%a %b %-d")
+        day = get_formatted_date(start_date, include_time=False)
     else:
         # Convert start/end to local time
         start_date = start_date.replace(tzinfo=tz.tzutc())
@@ -83,11 +83,11 @@ def get_outlook_datetime_formatted(event):
         end_date = end_date.replace(tzinfo=tz.tzutc())
         end_date = end_date.astimezone(tz.tzlocal())
         if(start_date.date() == end_date.date()):
-            start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
+            start_formatted = get_formatted_date(start_date)
             end_formatted = end_date.strftime("%-I:%M %p")
         else:
-            start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
-            end_formatted = end_date.strftime("%a %b %-d, %-I:%M %p")
+            start_formatted = get_formatted_date(start_date)
+            end_formatted = get_formatted_date(end_date)
         day = "{} - {}".format(start_formatted, end_formatted)
     return day
 

--- a/screen-calendar-get.py
+++ b/screen-calendar-get.py
@@ -147,18 +147,14 @@ def get_google_datetime_formatted(event_start, event_end):
         start_date = datetime.datetime.strptime(event_start.get('dateTime'), "%Y-%m-%dT%H:%M:%S%z")
         end_date = datetime.datetime.strptime(event_end.get('dateTime'), "%Y-%m-%dT%H:%M:%S%z")
         if(start_date.date() == end_date.date()):
-            #start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
             start_formatted = get_formatted_date(start_date)
             end_formatted = end_date.strftime("%-I:%M %p")
         else:
-            #start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
             start_formatted = get_formatted_date(start_date)
-            #end_formatted = end_date.strftime("%a %b %-d, %-I:%M %p")
             end_formatted = get_formatted_date(end_date)
         day = "{} - {}".format(start_formatted, end_formatted)
     else:
         start = event_start.get('date')
-        #day = time.strftime("%a %b %-d", time.strptime(start, "%Y-%m-%d"))
         day = get_formatted_date(datetime.datetime.strptime(start, "%Y-%m-%d"), include_time=False)
     return day
 

--- a/screen-calendar-get.py
+++ b/screen-calendar-get.py
@@ -147,17 +147,39 @@ def get_google_datetime_formatted(event_start, event_end):
         start_date = datetime.datetime.strptime(event_start.get('dateTime'), "%Y-%m-%dT%H:%M:%S%z")
         end_date = datetime.datetime.strptime(event_end.get('dateTime'), "%Y-%m-%dT%H:%M:%S%z")
         if(start_date.date() == end_date.date()):
-            start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
+            #start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
+            start_formatted = get_formatted_date(start_date)
             end_formatted = end_date.strftime("%-I:%M %p")
         else:
-            start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
-            end_formatted = end_date.strftime("%a %b %-d, %-I:%M %p")
+            #start_formatted = start_date.strftime("%a %b %-d, %-I:%M %p")
+            start_formatted = get_formatted_date(start_date)
+            #end_formatted = end_date.strftime("%a %b %-d, %-I:%M %p")
+            end_formatted = get_formatted_date(end_date)
         day = "{} - {}".format(start_formatted, end_formatted)
     else:
         start = event_start.get('date')
-        day = time.strftime("%a %b %-d", time.strptime(start, "%Y-%m-%d"))
+        #day = time.strftime("%a %b %-d", time.strptime(start, "%Y-%m-%d"))
+        day = get_formatted_date(datetime.datetime.strptime(start, "%Y-%m-%d"), include_time=False)
     return day
 
+def get_formatted_date(dt, include_time=True):
+    today = datetime.datetime.today()
+    tomorrow = today + datetime.timedelta(days=1)
+    next_week = today + datetime.timedelta(days=7)
+    formatter_day = "%a %b %-d"
+    formatter_time = ""
+
+    if include_time:
+        formatter_time = ", %-I:%M %p"
+
+    if dt.date() == today.date():
+        formatter_day = "Today"
+    elif dt.date() == tomorrow.date():
+        formatter_day = "Tomorrow"
+    elif dt.date() < next_week.date():
+        formatter_day = "%A"
+    return dt.strftime(formatter_day + formatter_time)
+    
 
 def main():
 

--- a/screen-calendar-get.py
+++ b/screen-calendar-get.py
@@ -8,7 +8,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
 import outlook_util
-from utility import is_stale, update_svg, configure_logging
+from utility import is_stale, update_svg, configure_logging, get_formatted_date
 
 configure_logging()
 
@@ -162,24 +162,6 @@ def get_google_datetime_formatted(event_start, event_end):
         day = get_formatted_date(datetime.datetime.strptime(start, "%Y-%m-%d"), include_time=False)
     return day
 
-def get_formatted_date(dt, include_time=True):
-    today = datetime.datetime.today()
-    tomorrow = today + datetime.timedelta(days=1)
-    next_week = today + datetime.timedelta(days=7)
-    formatter_day = "%a %b %-d"
-    formatter_time = ""
-
-    if include_time:
-        formatter_time = ", %-I:%M %p"
-
-    if dt.date() == today.date():
-        formatter_day = "Today"
-    elif dt.date() == tomorrow.date():
-        formatter_day = "Tomorrow"
-    elif dt.date() < next_week.date():
-        formatter_day = "%A"
-    return dt.strftime(formatter_day + formatter_time)
-    
 
 def main():
 

--- a/screen-weather-get.py
+++ b/screen-weather-get.py
@@ -127,8 +127,8 @@ def get_alert_message(location_lat, location_long):
 
 def main():
 
-    location_lat = os.getenv("WEATHER_LATITUDE", "51.3656")
-    location_long = os.getenv("WEATHER_LONGITUDE", "-0.1963")
+    location_lat = os.getenv("WEATHER_LATITUDE", "51.5077")
+    location_long = os.getenv("WEATHER_LONGITUDE", "-0.1277")
     weather_format = os.getenv("WEATHER_FORMAT", "CELSIUS")
 
     if (weather_format == "CELSIUS"):

--- a/utility.py
+++ b/utility.py
@@ -140,7 +140,7 @@ def get_formatted_date(dt, include_time=True):
 
     if dt.date() == today.date():
         formatter_day = "Today"
-        if dt >= get_sunset_time():
+        if dt.astimezone() >= get_sunset_time():
             formatter_day = "Tonight"
     elif dt.date() == tomorrow.date():
         formatter_day = "Tomorrow"

--- a/utility.py
+++ b/utility.py
@@ -6,8 +6,11 @@ import contextlib
 from http.client import HTTPConnection # py3
 import requests
 import datetime
+import pytz
 import json
 import xml.etree.ElementTree as ET
+from astral import LocationInfo
+from astral.sun import sun
 
 def configure_logging():
     """
@@ -137,9 +140,21 @@ def get_formatted_date(dt, include_time=True):
 
     if dt.date() == today.date():
         formatter_day = "Today"
+        if dt >= get_sunset_time():
+            formatter_day = "Tonight"
     elif dt.date() == tomorrow.date():
         formatter_day = "Tomorrow"
     elif dt.date() < next_week.date():
         formatter_day = "%A"
     return dt.strftime(formatter_day + formatter_time)
-        
+
+def get_sunset_time():
+    """
+    Return the time at which darkness begins, aka 'tonight'
+    """
+    location_lat = os.getenv("WEATHER_LATITUDE", "51.3656")
+    location_long = os.getenv("WEATHER_LONGITUDE", "-0.1963")
+    dt = datetime.datetime.now(pytz.utc)
+    city = LocationInfo(location_lat, location_long)
+    s = sun(city.observer, date=dt)
+    return s['sunset']

--- a/utility.py
+++ b/utility.py
@@ -5,6 +5,7 @@ import time
 import contextlib
 from http.client import HTTPConnection # py3
 import requests
+import datetime
 import json
 import xml.etree.ElementTree as ET
 
@@ -126,3 +127,22 @@ def get_xml_from_url(url, headers, cache_file_name, ttl):
             response_data = file.read()
     response_xml = ET.fromstring(response_data)
     return response_xml
+
+def get_formatted_date(dt, include_time=True):
+    today = datetime.datetime.today()
+    tomorrow = today + datetime.timedelta(days=1)
+    next_week = today + datetime.timedelta(days=7)
+    formatter_day = "%a %b %-d"
+    formatter_time = ""
+
+    if include_time:
+        formatter_time = ", %-I:%M %p"
+
+    if dt.date() == today.date():
+        formatter_day = "Today"
+    elif dt.date() == tomorrow.date():
+        formatter_day = "Tomorrow"
+    elif dt.date() < next_week.date():
+        formatter_day = "%A"
+    return dt.strftime(formatter_day + formatter_time)
+        

--- a/utility.py
+++ b/utility.py
@@ -152,8 +152,8 @@ def get_sunset_time():
     """
     Return the time at which darkness begins, aka 'tonight'
     """
-    location_lat = os.getenv("WEATHER_LATITUDE", "51.3656")
-    location_long = os.getenv("WEATHER_LONGITUDE", "-0.1963")
+    location_lat = os.getenv("WEATHER_LATITUDE", "51.5077")
+    location_long = os.getenv("WEATHER_LONGITUDE", "-0.1277")
     dt = datetime.datetime.now(pytz.utc)
     city = LocationInfo(location_lat, location_long)
     s = sun(city.observer, date=dt)

--- a/utility.py
+++ b/utility.py
@@ -133,10 +133,7 @@ def get_formatted_date(dt, include_time=True):
     tomorrow = today + datetime.timedelta(days=1)
     next_week = today + datetime.timedelta(days=7)
     formatter_day = "%a %b %-d"
-    formatter_time = ""
-
-    if include_time:
-        formatter_time = ", %-I:%M %p"
+    formatter_time = ", %-I:%M %p" if include_time else ""
 
     if dt.date() == today.date():
         formatter_day = "Today"


### PR DESCRIPTION
This PR uses friendly day names for events which are happening soon (Today, Monday...). It removes the date (Apr 11) for coming-soon events.  I saw this on [jmason's fork](https://github.com/jmason/waveshare-epaper-display/tree/jmason/met-eireann-weather-provider) and wanted to reimplement it here with some extra logic.  

If the event is today, use the word '**Today**' instead of 'Friday'.   

If the event is today after sunset, use the word '**Tonight**' instead of 'Today'.   
(Is that going too far?)

If the event is tomorrow, use the word '**Tomorrow**' instead of 'Saturday'.  

If the event is within the next 6 days, just display the day name '**Monday**' instead of 'Monday Apr 11'. 
(Should this be within the next 3 days instead of 6 days?)

Finally, just use the regular '**Sat Apr 16**...' format for events beyond that. 

![image](https://user-images.githubusercontent.com/746276/162534339-ec812002-e961-47e3-aea2-f4f5a87deb6b.png)
