### PR TITLE
Downgrade 'cryptography'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ caldav==0.10.0
 certifi==2022.9.24
 cffi==1.15.1
 charset-normalizer==2.1.1
-cryptography==38.0.3
+cryptography==38.0.2
 cssselect2==0.7.0
 DateTime==4.3
 defusedxml==0.7.1


### PR DESCRIPTION
Downgrade 'cryptography' as its package was yanked in the wheels. See: https://www.piwheels.org/project/cryptography/