### PR TITLE
Upgraded version of Openweathermap api to 3.0 due to deprecation of 2.5

### DIFF
--- a/weather_providers/openweathermap.py
+++ b/weather_providers/openweathermap.py
@@ -82,7 +82,7 @@ class OpenWeatherMap(BaseWeatherProvider):
     # https://openweathermap.org/api/one-call-api
     def get_weather(self):
 
-        url = ("https://api.openweathermap.org/data/2.5/onecall?lat={}&lon={}&exclude=current,minutely,hourly&units={}&appid={}"
+        url = ("https://api.openweathermap.org/data/3.0/onecall?lat={}&lon={}&exclude=current,minutely,hourly&units={}&appid={}"
                .format(self.location_lat, self.location_long, self.units, self.openweathermap_apikey))
         response_data = self.get_response_json(url)
         logging.debug(response_data)


### PR DESCRIPTION
Since Openweathermap deprecated 2.5 version of the Onecall api, I upgraded to 3.0
The old call is compatible with the new one: https://openweathermap.org/api/one-call-3#current

Some links regarding the deprecation:
https://github.com/csparpa/pyowm/issues/404
https://github.com/domoticz/domoticz/issues/5336