### PR TITLE
Update icalevnt 0.1.26 to icalevents.0.1.27

### DIFF
--- a/calendar_providers/ics.py
+++ b/calendar_providers/ics.py
@@ -5,7 +5,7 @@ from utility import is_stale
 import os
 import logging
 import pickle
-import icalevnt.icalevents
+import icalevents.icalevents
 from dateutil import tz
 
 ttl = float(os.getenv("CALENDAR_TTL", 1 * 60 * 60))
@@ -25,7 +25,7 @@ class ICSCalendar(BaseCalendarProvider):
         if is_stale(os.getcwd() + "/" + ics_calendar_pickle, ttl):
             logging.debug("Pickle is stale, fetching ICS Calendar")
 
-            ics_events = icalevnt.icalevents.events(self.ics_calendar_url, start=self.from_date, end=self.to_date)
+            ics_events = icalevents.icalevents.events(self.ics_calendar_url, start=self.from_date, end=self.to_date)
             ics_events.sort(key=lambda x: x.start.replace(tzinfo=None))
 
             logging.debug(ics_events)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ googleapis-common-protos==1.56.4
 httplib2==0.20.1
 humanize==4.6.0
 icalendar==4.0.8
-icalevnt==0.1.26
+icalevents==0.1.27
 idna==3.4
 lxml==4.9.1
 msal==1.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ google-auth==2.14.1
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.7.1
 googleapis-common-protos==1.56.4
-httplib2==0.20.1
+httplib2==0.20.4
 humanize==4.6.0
-icalendar==4.0.8
+icalendar==4.0.9
 icalevents==0.1.27
 idna==3.4
 lxml==4.9.1


### PR DESCRIPTION
Switch from `icalevnt==0.1.26` to `icalevents==0.1.27` and update the `ics.py` with the new model name. This fixed an issue in 0.1.26 that show event on Jan 12 4:30pm PST as Jan 11 4:30pm PST. 