### PR TITLE
Update Met Eireann integration to handle new URL

### DIFF
--- a/alert_providers/meteireann.py
+++ b/alert_providers/meteireann.py
@@ -15,6 +15,9 @@ class MetEireannAlertProvider(BaseAlertProvider):
         logging.debug("get_alert() - {}".format(alert_data))
 
         for item in alert_data:
+            # ignore potato blight warnings, as I'm not a potato farmer?
+            if item["headline"] == "Blight Advisory":
+              continue
             level = item["level"].capitalize()  	# "yellow" => "Yellow"
             # add the level to the description to make something like
             # "Yellow: Wind warning for Donegal, Leitrim, Mayo, Sligo"

--- a/weather_providers/meteireann.py
+++ b/weather_providers/meteireann.py
@@ -160,7 +160,7 @@ class MetEireann(BaseWeatherProvider):
     # Get weather from Met Eireann's open data API:
     # https://data.gov.ie/dataset/met-eireann-weather-forecast-api
     def get_weather(self):
-        url = ("http://metwdb-openaccess.ichec.ie/metno-wdb2ts/locationforecast?lat={};long={}"
+        url = ("http://openaccess.pf.api.met.ie/metno-wdb2ts/locationforecast?lat={};long={}"
                .format(self.location_lat, self.location_long))
 
         root = self.get_response_xml(url)


### PR DESCRIPTION
According to the Irish Government open data website at https://data.gov.ie/dataset/fa9574c1-48f4-4a98-a22b-d1c23c433821/resource/5d156b15-38b8-4de9-921b-0ffc8704c88e :

```
    Announcement: The upgrade of the api will result in termination of the
    old 'metwdb-openaccess.ichec.ie' URL by 15th September. This is replaced
    with 'openaccess.pf.api.met.ie'.

    URLs of the form:
    http://metwdb-openaccess.ichec.ie/metno-wdb2ts/locationforecast
    should be replaced with
    http://openaccess.pf.api.met.ie/metno-wdb2ts/locationforecast

    Disclaimer This API services and data offering is scheduled for upgrade
    starting Q1 2024. Every effort will be made to maintain data access
    during the upgrade period, and services/data will be provided on a best
    effort basis.
```

This also inhibits Met Eireann alerts about potato blight -- these are a little underwhelming for the non-potato-farmers among us :)