### PR TITLE
Add google client application for Google Calendar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 mendhak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -238,13 +238,15 @@ Run:
 The script will prompt you to visit a URL in your browser, then it will sit there and wait. The URL will look like `https://accounts.google.com/o/...` and will be very long.  
 
 Follow that URL in a browser window, you'll need to log in and choose your Google account.   
-Click continue on the "Make sure you trust Mendhak Waveshare Epaper Display" screen, and then let it fail when it tries to go to a `http://localhost:8080/...` URL.  
+On the "Make sure you trust Mendhak Waveshare Epaper Display" screen, you will see it's asking for permission to read your Google Calendar.  
+Click continue, and then let it fail when it tries to go to a `http://localhost:8080/...` URL.  
 
 Copy the URL it was trying to go to (eg: http://localhost:8080/...) and in another SSH session with the Raspberry Pi, run this (remember the double quotes): 
 
     curl "http://localhost:8080/..."
 
-On the first screen you should see the auth flow complete, and a new `token.pickle` file appears.  The script should now be able to run in the future without prompting required.
+On the first screen you should see the auth flow complete, and a new `token.pickle` file appears.   
+The script should now be able to run in the future without prompting required.
 
 
 ### Outlook Calendar

--- a/README.md
+++ b/README.md
@@ -229,23 +229,23 @@ export GOOGLE_CALENDAR_ID=xyz12345@group.calendar.google.com
 
 #### Google Calendar token
 
-The Oauth process needs to complete once manually in order to allow the Python code to then continuously query Google Calendar for information.
+You will need to run an Oauth process once manually to allow the Python code to get a token, which lets it query Google Calendar for information.
 
-Go to the [Google Cloud Platform library page](https://console.cloud.google.com/apis/library), search for and enable the [Calendar API](https://console.cloud.google.com/apis/api/calendar-json.googleapis.com/overview).
-
-Next, head over to the [API Dashboard Credentials page](https://console.cloud.google.com/apis/credentials), and create new credentials of type "OAuth Client ID".  For application type, choose "Desktop app" and give it a name such as "Epaper Display".  When presented, download or copy the `credentials.json` file and add it to this directory.
-
-You can now kick off the authentication process. On the Raspberry Pi, run:
+Run:
 
     .venv/bin/python3 screen-calendar-get.py
 
-The script will prompt you to visit a URL in your browser and then wait.  Copy the URL, open it in a browser and you will go through the login process.  When the OAuth workflow tries to redirect back (and fails), copy the URL it was trying to go to (eg: http://localhost:8080/...) and in another SSH session with the Raspberry Pi,
+The script will prompt you to visit a URL in your browser, then it will sit there and wait. The URL will look like `https://accounts.google.com/o/...` and will be very long.  
+
+Follow that URL in a browser window, you'll need to log in and choose your Google account.   
+Click continue on the "Make sure you trust Mendhak Waveshare Epaper Display" screen, and then let it fail when it tries to go to a `http://localhost:8080/...` URL.  
+
+Copy the URL it was trying to go to (eg: http://localhost:8080/...) and in another SSH session with the Raspberry Pi, run this (remember the double quotes): 
 
     curl "http://localhost:8080/..."
 
-On the first screen you should see the auth flow complete, and a new `token.pickle` file appears.  The Python script should now be able to run in the future without prompting required.
+On the first screen you should see the auth flow complete, and a new `token.pickle` file appears.  The script should now be able to run in the future without prompting required.
 
-I also have a [post here with screenshots](https://github.com/mendhak/waveshare-epaper-display/issues/19#issuecomment-780397819) walking through the process.
 
 ### Outlook Calendar
 

--- a/calendar_providers/google.py
+++ b/calendar_providers/google.py
@@ -44,6 +44,11 @@ class GoogleCalendar(BaseCalendarProvider):
                     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                     "token_uri": "https://oauth2.googleapis.com/token",
                     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                    # Pointless xor. For embedded/desktop apps, the client secret is not considered a secret but is called a secret 🙃
+                    # So here it's just for storage.
+                    # https://stackoverflow.com/questions/71111416/how-to-protect-client-credentials-in-a-desktop-app
+                    # https://stackoverflow.com/questions/59416326/safely-distribute-oauth-2-0-client-secret-in-desktop-applications-in-python
+                    # https://stackoverflow.com/questions/78857716/can-i-include-google-oauth-client-secret-in-my-desktop-application
                     "client_secret": xor_decode("HwI5FzprZiBiE0AtJ3A7IjZ+LB4VCBQjHmcIN1IBJz0QBjg=", "XMzDj3Kb4j2j_3jK_8dwoeuir3mm3jKb"),
                     "redirect_uris": ["http://localhost"]}}, google_api_scopes)
 

--- a/calendar_providers/google.py
+++ b/calendar_providers/google.py
@@ -1,6 +1,6 @@
 import datetime
 from calendar_providers.base_provider import BaseCalendarProvider, CalendarEvent
-from utility import is_stale
+from utility import is_stale, xor_decode
 import os
 import logging
 import pickle
@@ -22,7 +22,7 @@ class GoogleCalendar(BaseCalendarProvider):
     def get_google_credentials(self):
 
         google_token_pickle = 'token.pickle'
-        google_credentials_json = 'credentials.json'
+
         google_api_scopes = ['https://www.googleapis.com/auth/calendar.readonly']
 
         credentials = None
@@ -38,8 +38,15 @@ class GoogleCalendar(BaseCalendarProvider):
             if credentials and credentials.expired and credentials.refresh_token:
                 credentials.refresh(Request())
             else:
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    google_credentials_json, google_api_scopes)
+                flow = InstalledAppFlow.from_client_config({"installed": {
+                    "client_id": "872428123454-jjp9mvs2ha4at913874ik2ua6fosi23d.apps.googleusercontent.com",
+                    "project_id": "waveshare-epaper-display",
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                    "client_secret": xor_decode("HwI5FzprZiBiE0AtJ3A7IjZ+LB4VCBQjHmcIN1IBJz0QBjg=", "XMzDj3Kb4j2j_3jK_8dwoeuir3mm3jKb"),
+                    "redirect_uris": ["http://localhost"]}}, google_api_scopes)
+
                 credentials = flow.run_local_server()
             # Save the credentials for the next run
             with open(google_token_pickle, 'wb') as token:

--- a/utility.py
+++ b/utility.py
@@ -1,3 +1,4 @@
+import base64
 import codecs
 import logging
 import os
@@ -197,3 +198,30 @@ def get_sunset_time():
     city = LocationInfo(location_lat, location_long)
     s = sun(city.observer, date=dt)
     return s['sunset']
+
+
+def xor_encode(data, key):
+    """XOR encode/decode the input data with a key."""
+    # Repeat the key to match the length of data
+    extended_key = (key * (len(data) // len(key) + 1))[:len(data)]
+
+    # XOR each byte
+    xored = bytes(a ^ b for a, b in zip(data.encode(), extended_key.encode()))
+
+    return base64.b64encode(xored).decode()
+
+
+def xor_decode(encoded_data, key):
+    """XOR decode the input data with a key.
+       Completely pointless and lightweight obfuscation, accomplishes nothing.
+    """
+    # Decode base64 first
+    decoded_bytes = base64.b64decode(encoded_data.encode())
+
+    # Repeat the key to match the length of data
+    extended_key = (key * (len(decoded_bytes) // len(key) + 1))[:len(decoded_bytes)]
+
+    # XOR each byte back
+    xored = bytes(a ^ b for a, b in zip(decoded_bytes, extended_key.encode()))
+
+    return xored.decode()


### PR DESCRIPTION
Issue #98  and others. 

Instead of getting people to create their own Google Cloud application, and dealing with the increasingly convoluted differences that Google keep introducing, I've created an application myself and I'm just going to distribute it here. 

It's so unclear about storing the client_secret in source code. Google's docs say that in this case, client_secret is not a secret. Well, then why is it called a secret?

https://stackoverflow.com/questions/71111416/how-to-protect-client-credentials-in-a-desktop-app
https://stackoverflow.com/questions/59416326/safely-distribute-oauth-2-0-client-secret-in-desktop-applications-in-python
https://stackoverflow.com/questions/78857716/can-i-include-google-oauth-client-secret-in-my-desktop-app