### PR TITLE
Add systemd timer and service examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,16 @@ Add this entry so it runs every minute:
 
 This will cause the script to run every minute, and write the output as well as errors to the run.log file.
 
+Alternatively, you can use a systemd timer. There are example systemd units available to install a timer
+that starts a service every minute that runs the script. To achieve this, execute the following commands.
+
+    mkdir -p ~/.config/systemd/user/
+    cp waveshare-epaper-display.service.example ~/.config/systemd/user/waveshare-epaper-display.service
+    cp waveshare-epaper-display.timer.example ~/.config/systemd/user/waveshare-epaper-display.timer
+    systemctl --user daemon-reload
+    systemctl --user enable waveshare-epaper-display.timer
+    loginctl enable-linger
+
 ## Custom Data
 
 This is an optional step, to add your own custom data to the screen.  For example this could be API calls, data from Home Assistant, PiHole stats, or something external.

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 . env.sh
 

--- a/waveshare-epaper-display.service.example
+++ b/waveshare-epaper-display.service.example
@@ -1,0 +1,10 @@
+[Unit]
+Description=Waveshare ePaper display update service
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/waveshare-epaper-display/
+ExecStart=%h/waveshare-epaper-display/run.sh
+
+[Install]
+WantedBy=default.target

--- a/waveshare-epaper-display.timer.example
+++ b/waveshare-epaper-display.timer.example
@@ -1,0 +1,10 @@
+[Unit]
+Description=Waveshare ePaper display update timer
+
+[Timer]
+OnActiveSec=0
+OnUnitActiveSec=1m
+Unit=waveshare-epaper-display.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The `README.md` file explains how to automate the display update using a cron job, but the modern approach to schedule execution for recurring tasks is to use systemd timers instead.

This PR add a `waveshare-epaper-display.timer.example` and `waveshare-epaper-display.service.example` unit files and documents how can be used to automate to schedule the execution of the `run.sh` script.